### PR TITLE
Remove obsolete API URLs from cheatsheet

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -223,10 +223,6 @@ Refering to the above, the lower and higher, we can represent uint64 id in a hex
 
 - https://betelgeuse.xpxsirius.io
 
-- https://bigcalvin.xpxsirius.io
-
-- https://delphinus.xpxsirius.io
-
 - https://lyrasithara.xpxsirius.io
 
 ### Testnet 2


### PR DESCRIPTION
Removed outdated links from the cheatsheet.